### PR TITLE
Add addons-search-experiment

### DIFF
--- a/manifests/addons-search-experiment.yml
+++ b/manifests/addons-search-experiment.yml
@@ -1,0 +1,9 @@
+description: Search experiment by the add-ons team
+repo-prefix: addonssearchexperiment
+active: true
+private-repo: false
+branch: main
+artifacts:
+  - web-ext-artifacts/addons-search-experiment.xpi
+addon-type: system
+install-type: yarn

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -165,6 +165,12 @@ taskgraph:
             default-repository: https://github.com/mozilla-extensions/balrog-dryrun.git
             default-ref: main
             type: git
+        addonssearchexperiment:
+            name: "Add-ons Search Experiment extension"
+            project-regex: addonssearchexperiment$
+            default-repository: https://github.com/mozilla-extensions/addons-search-experiment
+            default-ref: main
+            type: git
 
 
     cached-task-prefix: xpi


### PR DESCRIPTION
This PR adds the configuration for the [addons-search-experiment](https://github.com/mozilla-extensions/addons-search-experiment) designed by the add-ons team.

cc @wagnerand and @mixedpuppy